### PR TITLE
The master branch for meta-altera does not support warrior.

### DIFF
--- a/yocto2.7-build
+++ b/yocto2.7-build
@@ -360,7 +360,7 @@ git clone -b warrior git://git.yoctoproject.org/poky.git
 
 # Clone meta-altera repo
 
-git clone -b master git://github.com/kraj/meta-altera.git
+git clone -b dunfell git://github.com/kraj/meta-altera.git
 
 # Clone meta-arrow-sockit repo
 


### PR DESCRIPTION
The branch `master` in `kraj/meta-altera` only supports `honister` and `kirkstone` check https://github.com/kraj/meta-altera/blob/master/conf/layer.conf#L11 Only the branch `dunfell` in `kraj/meta-altera` support `warrior` check https://github.com/kraj/meta-altera/blob/dunfell/conf/layer.conf#L11